### PR TITLE
Readme: Explicitly call out no buildpack.yml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,7 @@ $ ./scripts/package.sh
 This builds the buildpack's Go source using `GOOS=linux` by default. You can
 supply another value as the first argument to `package.sh`.
 
+## `buildpack.yml` Configurations
 
+The `yarn-install` buildpack does not support configurations using `buildpack.yml`.
 


### PR DESCRIPTION
[#172333965]

Co-authored-by: Arjun Sreedharan <asreedharan@pivotal.io>