### PR TITLE
Uses occam.Source to allow integration specs to run in parallel

### DIFF
--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -30,7 +31,8 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 		var (
 			image occam.Image
 
-			name string
+			name   string
+			source string
 		)
 
 		it.Before(func() {
@@ -42,15 +44,19 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 		it.After(func() {
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
 		it("should build a working OCI image for a simple app", func() {
 			var err error
+			source, err = occam.Source(filepath.Join("testdata", "simple_app"))
+			Expect(err).NotTo(HaveOccurred())
+
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithBuildpacks(nodeURI, yarnURI).
 				WithNoPull().
-				Execute(name, filepath.Join("testdata", "simple_app"))
+				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			buildpackVersion, err := GetGitVersion()
@@ -82,7 +88,8 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 		var (
 			image occam.Image
 
-			name string
+			name   string
+			source string
 		)
 
 		it.Before(func() {
@@ -94,15 +101,19 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 		it.After(func() {
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
 		it("should build a working OCI image for a simple app", func() {
 			var err error
+			source, err = occam.Source(filepath.Join("testdata", "vendored"))
+			Expect(err).NotTo(HaveOccurred())
+
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithBuildpacks(nodeURI, yarnURI).
 				WithNoPull().
-				Execute(name, filepath.Join("testdata", "vendored"))
+				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			buildpackVersion, err := GetGitVersion()

--- a/integration/module_binaries_test.go
+++ b/integration/module_binaries_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +34,8 @@ func testModuleBinaries(t *testing.T, context spec.G, it spec.S) {
 			image     occam.Image
 			container occam.Container
 
-			name string
+			name   string
+			source string
 		)
 
 		it.Before(func() {
@@ -46,15 +48,19 @@ func testModuleBinaries(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
 		it("builds a working OCI image for a vendored app with binary", func() {
 			var err error
+			source, err = occam.Source(filepath.Join("testdata", "module_binaries"))
+			Expect(err).NotTo(HaveOccurred())
+
 			var logs fmt.Stringer
 			image, logs, err = pack.WithVerbose().WithNoColor().Build.
 				WithNoPull().
 				WithBuildpacks(nodeURI, yarnURI).
-				Execute(name, filepath.Join("testdata", "module_binaries"))
+				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)
 
 			container, err = docker.Container.Run.WithTTY().WithCommand(`chalk bold 'PAKETO' && yarn start`).Execute(image.ID)

--- a/integration/pre_gyp_test.go
+++ b/integration/pre_gyp_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,7 +33,8 @@ func testPreGyp(t *testing.T, context spec.G, it spec.S) {
 			image     occam.Image
 			container occam.Container
 
-			name string
+			name   string
+			source string
 		)
 
 		it.Before(func() {
@@ -45,14 +47,18 @@ func testPreGyp(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
 		it("should build a working OCI image for a simple app", func() {
 			var err error
+			source, err = occam.Source(filepath.Join("testdata", "yarn_pre_gyp"))
+			Expect(err).NotTo(HaveOccurred())
+
 			image, _, err = pack.Build.
 				WithBuildpacks(nodeURI, yarnURI).
 				WithNoPull().
-				Execute(name, filepath.Join("testdata", "yarn_pre_gyp"))
+				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			container, err = docker.Container.Run.Execute(image.ID)

--- a/integration/vendored_test.go
+++ b/integration/vendored_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,7 +33,8 @@ func testVendored(t *testing.T, context spec.G, it spec.S) {
 			image     occam.Image
 			container occam.Container
 
-			name string
+			name   string
+			source string
 		)
 
 		it.Before(func() {
@@ -45,14 +47,18 @@ func testVendored(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
 		it("should build a working OCI image for a simple app", func() {
 			var err error
+			source, err = occam.Source(filepath.Join("testdata", "vendored"))
+			Expect(err).NotTo(HaveOccurred())
+
 			image, _, err = pack.Build.
 				WithBuildpacks(nodeCachedURI, yarnCachedURI).
 				WithNetwork("none").
-				Execute(name, filepath.Join("testdata", "vendored"))
+				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
 			container, err = docker.Container.Run.Execute(image.ID)


### PR DESCRIPTION
occam.Source duplicates the source code directory and makes it unique by adding a file with unique random content.