### PR TITLE
Use full-builder to run integration tests like npm-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,13 @@ To run all integration tests, run:
 ```
 /scripts/integration.sh
 ```
+
+## Stack support
+
+For most apps, the Yarn Install Buildpack runs fine on the [Base
+builder](https://github.com/paketo-buildpacks/stacks#metadata-for-paketo-buildrun-stack-images).
+But when the app requires compilation of native extensions using `node-gyp`,
+the buildpack requires that you use the [Full
+builder](https://github.com/paketo-buildpacks/stacks#metadata-for-paketo-buildrun-stack-images).
+This is because `node-gyp` requires `python` that's absent on the Base builder,
+and the module may require other shared objects.

--- a/integration.json
+++ b/integration.json
@@ -1,4 +1,5 @@
 {
+  "builder": "index.docker.io/paketobuildpacks/builder:full",
   "build-plan": "github.com/ForestEckhardt/build-plan",
   "node-engine": "github.com/paketo-buildpacks/node-engine",
   "yarn": "github.com/paketo-buildpacks/yarn"


### PR DESCRIPTION
* A short explanation of the proposed change:

Looks like current bcrypt module in testdata/yarn_pre_gyp
uses native extensions and thus needs the full builder.


Please confirm the following:
* [X] I have viewed, signed, and submitted the Contributor License Agreement.

