### PR TITLE
Create intermediate symlink for switching between build and launch modules

### DIFF
--- a/build.go
+++ b/build.go
@@ -22,7 +22,7 @@ type SymlinkManager interface {
 //go:generate faux --interface InstallProcess --output fakes/install_process.go
 type InstallProcess interface {
 	ShouldRun(workingDir string, metadata map[string]interface{}) (run bool, sha string, err error)
-	SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath string) (string, error)
+	SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath, tempDir string) (string, error)
 	Execute(workingDir, modulesLayerPath string, launch bool) error
 }
 
@@ -114,7 +114,7 @@ func Build(pathParser PathParser,
 					return packit.BuildResult{}, err
 				}
 
-				currentModLayer, err = installProcess.SetupModules(context.WorkingDir, currentModLayer, layer.Path)
+				currentModLayer, err = installProcess.SetupModules(context.WorkingDir, currentModLayer, layer.Path, "/tmp")
 				if err != nil {
 					return packit.BuildResult{}, err
 				}
@@ -205,7 +205,7 @@ func Build(pathParser PathParser,
 					return packit.BuildResult{}, err
 				}
 
-				_, err = installProcess.SetupModules(context.WorkingDir, currentModLayer, layer.Path)
+				_, err = installProcess.SetupModules(context.WorkingDir, currentModLayer, layer.Path, "/tmp")
 				if err != nil {
 					return packit.BuildResult{}, err
 				}
@@ -253,7 +253,9 @@ func Build(pathParser PathParser,
 					}
 				}
 
-				layer.ExecD = []string{filepath.Join(context.CNBPath, "bin", "setup-symlinks")}
+				if build {
+					layer.ExecD = []string{filepath.Join(context.CNBPath, "bin", "setup-symlinks")}
+				}
 			} else {
 				logger.Process("Reusing cached layer %s", layer.Path)
 				if !build {

--- a/cmd/setup-symlinks/internal/run.go
+++ b/cmd/setup-symlinks/internal/run.go
@@ -7,19 +7,14 @@ import (
 	"strings"
 )
 
-func Run(executablePath, appDir string) error {
+func Run(executablePath, appDir, tempDir string) error {
 	fname := strings.Split(executablePath, "/")
 	layerPath := filepath.Join(fname[:len(fname)-2]...)
 	if filepath.IsAbs(executablePath) {
 		layerPath = fmt.Sprintf("/%s", layerPath)
 	}
 
-	err := os.RemoveAll(filepath.Join(appDir, "node_modules"))
-	if err != nil {
-		return err
-	}
-
-	err = os.Symlink(filepath.Join(layerPath, "node_modules"), filepath.Join(appDir, "node_modules"))
+	err := os.Symlink(filepath.Join(layerPath, "node_modules"), filepath.Join(tempDir, "node_modules"))
 	if err != nil {
 		return err
 	}

--- a/cmd/setup-symlinks/main.go
+++ b/cmd/setup-symlinks/main.go
@@ -13,7 +13,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = internal.Run(os.Args[0], wd)
+	err = internal.Run(os.Args[0], wd, "/tmp")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/fakes/binding_resolver.go
+++ b/fakes/binding_resolver.go
@@ -8,7 +8,7 @@ import (
 
 type BindingResolver struct {
 	ResolveCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Typ         string
@@ -24,8 +24,8 @@ type BindingResolver struct {
 }
 
 func (f *BindingResolver) Resolve(param1 string, param2 string, param3 string) ([]servicebindings.Binding, error) {
-	f.ResolveCall.mutex.Lock()
-	defer f.ResolveCall.mutex.Unlock()
+	f.ResolveCall.Lock()
+	defer f.ResolveCall.Unlock()
 	f.ResolveCall.CallCount++
 	f.ResolveCall.Receives.Typ = param1
 	f.ResolveCall.Receives.Provider = param2

--- a/fakes/configuration_manager.go
+++ b/fakes/configuration_manager.go
@@ -1,12 +1,10 @@
 package fakes
 
-import (
-	"sync"
-)
+import "sync"
 
 type ConfigurationManager struct {
 	DeterminePathCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Typ         string
@@ -22,8 +20,8 @@ type ConfigurationManager struct {
 }
 
 func (f *ConfigurationManager) DeterminePath(param1 string, param2 string, param3 string) (string, error) {
-	f.DeterminePathCall.mutex.Lock()
-	defer f.DeterminePathCall.mutex.Unlock()
+	f.DeterminePathCall.Lock()
+	defer f.DeterminePathCall.Unlock()
 	f.DeterminePathCall.CallCount++
 	f.DeterminePathCall.Receives.Typ = param1
 	f.DeterminePathCall.Receives.PlatformDir = param2

--- a/fakes/entry_resolver.go
+++ b/fakes/entry_resolver.go
@@ -8,7 +8,7 @@ import (
 
 type EntryResolver struct {
 	MergeLayerTypesCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			String                  string
@@ -23,8 +23,8 @@ type EntryResolver struct {
 }
 
 func (f *EntryResolver) MergeLayerTypes(param1 string, param2 []packit.BuildpackPlanEntry) (bool, bool) {
-	f.MergeLayerTypesCall.mutex.Lock()
-	defer f.MergeLayerTypesCall.mutex.Unlock()
+	f.MergeLayerTypesCall.Lock()
+	defer f.MergeLayerTypesCall.Unlock()
 	f.MergeLayerTypesCall.CallCount++
 	f.MergeLayerTypesCall.Receives.String = param1
 	f.MergeLayerTypesCall.Receives.BuildpackPlanEntrySlice = param2

--- a/fakes/executable.go
+++ b/fakes/executable.go
@@ -8,7 +8,7 @@ import (
 
 type Executable struct {
 	ExecuteCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Execution pexec.Execution
@@ -21,8 +21,8 @@ type Executable struct {
 }
 
 func (f *Executable) Execute(param1 pexec.Execution) error {
-	f.ExecuteCall.mutex.Lock()
-	defer f.ExecuteCall.mutex.Unlock()
+	f.ExecuteCall.Lock()
+	defer f.ExecuteCall.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.Execution = param1
 	if f.ExecuteCall.Stub != nil {

--- a/fakes/install_process.go
+++ b/fakes/install_process.go
@@ -1,12 +1,10 @@
 package fakes
 
-import (
-	"sync"
-)
+import "sync"
 
 type InstallProcess struct {
 	ExecuteCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			WorkingDir       string
@@ -19,21 +17,22 @@ type InstallProcess struct {
 		Stub func(string, string, bool) error
 	}
 	SetupModulesCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			WorkingDir              string
 			CurrentModulesLayerPath string
 			NextModulesLayerPath    string
+			TempDir                 string
 		}
 		Returns struct {
 			String string
 			Error  error
 		}
-		Stub func(string, string, string) (string, error)
+		Stub func(string, string, string, string) (string, error)
 	}
 	ShouldRunCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			WorkingDir string
@@ -51,8 +50,8 @@ type InstallProcess struct {
 }
 
 func (f *InstallProcess) Execute(param1 string, param2 string, param3 bool) error {
-	f.ExecuteCall.mutex.Lock()
-	defer f.ExecuteCall.mutex.Unlock()
+	f.ExecuteCall.Lock()
+	defer f.ExecuteCall.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.WorkingDir = param1
 	f.ExecuteCall.Receives.ModulesLayerPath = param2
@@ -62,22 +61,23 @@ func (f *InstallProcess) Execute(param1 string, param2 string, param3 bool) erro
 	}
 	return f.ExecuteCall.Returns.Error
 }
-func (f *InstallProcess) SetupModules(param1 string, param2 string, param3 string) (string, error) {
-	f.SetupModulesCall.mutex.Lock()
-	defer f.SetupModulesCall.mutex.Unlock()
+func (f *InstallProcess) SetupModules(param1 string, param2 string, param3 string, param4 string) (string, error) {
+	f.SetupModulesCall.Lock()
+	defer f.SetupModulesCall.Unlock()
 	f.SetupModulesCall.CallCount++
 	f.SetupModulesCall.Receives.WorkingDir = param1
 	f.SetupModulesCall.Receives.CurrentModulesLayerPath = param2
 	f.SetupModulesCall.Receives.NextModulesLayerPath = param3
+	f.SetupModulesCall.Receives.TempDir = param4
 	if f.SetupModulesCall.Stub != nil {
-		return f.SetupModulesCall.Stub(param1, param2, param3)
+		return f.SetupModulesCall.Stub(param1, param2, param3, param4)
 	}
 	return f.SetupModulesCall.Returns.String, f.SetupModulesCall.Returns.Error
 }
 func (f *InstallProcess) ShouldRun(param1 string, param2 map[string]interface {
 }) (bool, string, error) {
-	f.ShouldRunCall.mutex.Lock()
-	defer f.ShouldRunCall.mutex.Unlock()
+	f.ShouldRunCall.Lock()
+	defer f.ShouldRunCall.Unlock()
 	f.ShouldRunCall.CallCount++
 	f.ShouldRunCall.Receives.WorkingDir = param1
 	f.ShouldRunCall.Receives.Metadata = param2

--- a/fakes/path_parser.go
+++ b/fakes/path_parser.go
@@ -1,12 +1,10 @@
 package fakes
 
-import (
-	"sync"
-)
+import "sync"
 
 type PathParser struct {
 	GetCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Path string
@@ -20,8 +18,8 @@ type PathParser struct {
 }
 
 func (f *PathParser) Get(param1 string) (string, error) {
-	f.GetCall.mutex.Lock()
-	defer f.GetCall.mutex.Unlock()
+	f.GetCall.Lock()
+	defer f.GetCall.Unlock()
 	f.GetCall.CallCount++
 	f.GetCall.Receives.Path = param1
 	if f.GetCall.Stub != nil {

--- a/fakes/sbom_generator.go
+++ b/fakes/sbom_generator.go
@@ -8,7 +8,7 @@ import (
 
 type SBOMGenerator struct {
 	GenerateCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Dir string
@@ -22,8 +22,8 @@ type SBOMGenerator struct {
 }
 
 func (f *SBOMGenerator) Generate(param1 string) (sbom.SBOM, error) {
-	f.GenerateCall.mutex.Lock()
-	defer f.GenerateCall.mutex.Unlock()
+	f.GenerateCall.Lock()
+	defer f.GenerateCall.Unlock()
 	f.GenerateCall.CallCount++
 	f.GenerateCall.Receives.Dir = param1
 	if f.GenerateCall.Stub != nil {

--- a/fakes/summer.go
+++ b/fakes/summer.go
@@ -1,12 +1,10 @@
 package fakes
 
-import (
-	"sync"
-)
+import "sync"
 
 type Summer struct {
 	SumCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Paths []string
@@ -20,8 +18,8 @@ type Summer struct {
 }
 
 func (f *Summer) Sum(param1 ...string) (string, error) {
-	f.SumCall.mutex.Lock()
-	defer f.SumCall.mutex.Unlock()
+	f.SumCall.Lock()
+	defer f.SumCall.Unlock()
 	f.SumCall.CallCount++
 	f.SumCall.Receives.Paths = param1
 	if f.SumCall.Stub != nil {

--- a/fakes/symlink_manager.go
+++ b/fakes/symlink_manager.go
@@ -1,12 +1,10 @@
 package fakes
 
-import (
-	"sync"
-)
+import "sync"
 
 type SymlinkManager struct {
 	LinkCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Oldname string
@@ -18,7 +16,7 @@ type SymlinkManager struct {
 		Stub func(string, string) error
 	}
 	UnlinkCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Path string
@@ -31,8 +29,8 @@ type SymlinkManager struct {
 }
 
 func (f *SymlinkManager) Link(param1 string, param2 string) error {
-	f.LinkCall.mutex.Lock()
-	defer f.LinkCall.mutex.Unlock()
+	f.LinkCall.Lock()
+	defer f.LinkCall.Unlock()
 	f.LinkCall.CallCount++
 	f.LinkCall.Receives.Oldname = param1
 	f.LinkCall.Receives.Newname = param2
@@ -42,8 +40,8 @@ func (f *SymlinkManager) Link(param1 string, param2 string) error {
 	return f.LinkCall.Returns.Error
 }
 func (f *SymlinkManager) Unlink(param1 string) error {
-	f.UnlinkCall.mutex.Lock()
-	defer f.UnlinkCall.mutex.Unlock()
+	f.UnlinkCall.Lock()
+	defer f.UnlinkCall.Unlock()
 	f.UnlinkCall.CallCount++
 	f.UnlinkCall.Receives.Path = param1
 	if f.UnlinkCall.Stub != nil {

--- a/fakes/version_parser.go
+++ b/fakes/version_parser.go
@@ -1,12 +1,10 @@
 package fakes
 
-import (
-	"sync"
-)
+import "sync"
 
 type VersionParser struct {
 	ParseVersionCall struct {
-		mutex     sync.Mutex
+		sync.Mutex
 		CallCount int
 		Receives  struct {
 			Path string
@@ -20,8 +18,8 @@ type VersionParser struct {
 }
 
 func (f *VersionParser) ParseVersion(param1 string) (string, error) {
-	f.ParseVersionCall.mutex.Lock()
-	defer f.ParseVersionCall.mutex.Unlock()
+	f.ParseVersionCall.Lock()
+	defer f.ParseVersionCall.Unlock()
 	f.ParseVersionCall.CallCount++
 	f.ParseVersionCall.Receives.Path = param1
 	if f.ParseVersionCall.Stub != nil {

--- a/run/main.go
+++ b/run/main.go
@@ -50,6 +50,7 @@ func main() {
 			installProcess,
 			sbomGenerator,
 			chronos.DefaultClock,
-			emitter),
+			emitter,
+		),
 	)
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Avoids changing `/workspace` permissions, creating instead a symlink in `/tmp` which points to build modules during build and launch modules at launch. The `/tmp` symlink is pointed to by the `node_modules` symlink in `/workspace` (i.e. `/workspace/node_modules` -> `/tmp/node_modules` -> `{build, launch}-modules` layer).

The `exec.d` script is now only run when `node_modules` is required for both build and launch. If `node_modules` is only required at launch, `/workspace/node_modules` would already be symlinked to `/layers/.../launch-modules/node_modules` so the exec.d script wouldn't be necessary.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This allows users to build apps when the build-time and run-time uids are different.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
