### PR TITLE
Only use cache layer if yarn.lock AND package.json match

### DIFF
--- a/install_process.go
+++ b/install_process.go
@@ -78,7 +78,7 @@ func (ip YarnInstallProcess) ShouldRun(workingDir string, metadata map[string]in
 		return true, "", fmt.Errorf("failed to write temp file for %s: %w", file.Name(), err)
 	}
 
-	sum, err := ip.summer.Sum(filepath.Join(workingDir, "yarn.lock"), file.Name())
+	sum, err := ip.summer.Sum(filepath.Join(workingDir, "yarn.lock"), filepath.Join(workingDir, "package.json"), file.Name())
 	if err != nil {
 		return true, "", fmt.Errorf("unable to sum config files: %w", err)
 	}

--- a/install_process_test.go
+++ b/install_process_test.go
@@ -79,7 +79,8 @@ func testInstallProcess(t *testing.T, context spec.G, it spec.S) {
 						"cache_sha": "some-sha",
 					})
 					Expect(summer.SumCall.Receives.Paths[0]).To(Equal(filepath.Join(workingDir, "yarn.lock")))
-					Expect(summer.SumCall.Receives.Paths[1]).To(ContainSubstring("config-file"))
+					Expect(summer.SumCall.Receives.Paths[1]).To(Equal(filepath.Join(workingDir, "package.json")))
+					Expect(summer.SumCall.Receives.Paths[2]).To(ContainSubstring("config-file"))
 					Expect(run).To(BeTrue())
 					Expect(sha).To(Equal("some-other-sha"))
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
Fixes https://github.com/paketo-buildpacks/yarn-install/issues/143

## Summary
<!-- A short explanation of the proposed change -->
When checking the `sha` in the metadata if the cache layer can be reused, not only check `yarn.lock` but also `package.json` for changes. This also aligns the behaviour with `npm-install` where `package.json` and `package.lock` are used to calculate the `sha`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
If the user somehow changes the `package.json` without changing `yarn.lock`, this will now not use the cached layer, but install the packages again with the changed `package.json`.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
